### PR TITLE
Dev/issue 18

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -135,10 +135,14 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.distanceLayout = self.logic.get("distanceLayout")
         self.distanceTable = qt.QTableWidget()
         self.directoryExportDistance = ctk.ctkDirectoryButton()
+        self.filenameExportDistance = qt.QLineEdit('distance.csv')
         self.exportDistanceButton = qt.QPushButton(" Export ")
         self.exportDistanceButton.enabled = True
+        self.pathExportDistanceLayout = qt.QVBoxLayout()
+        self.pathExportDistanceLayout.addWidget(self.directoryExportDistance)
+        self.pathExportDistanceLayout.addWidget(self.filenameExportDistance)
         self.exportDistanceLayout = qt.QHBoxLayout()
-        self.exportDistanceLayout.addWidget(self.directoryExportDistance)
+        self.exportDistanceLayout.addLayout(self.pathExportDistanceLayout)
         self.exportDistanceLayout.addWidget(self.exportDistanceButton)
         self.tableAndExportLayout = qt.QVBoxLayout()
         self.tableAndExportLayout.addWidget(self.distanceTable)
@@ -182,10 +186,14 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.angleLayout = self.logic.get("angleLayout")
         self.anglesTable = qt.QTableWidget()
         self.directoryExportAngle = ctk.ctkDirectoryButton()
+        self.filenameExportAngle = qt.QLineEdit('angle.csv')
         self.exportAngleButton = qt.QPushButton("Export")
         self.exportAngleButton.enabled = True
+        self.pathExportAngleLayout = qt.QVBoxLayout()
+        self.pathExportAngleLayout.addWidget(self.directoryExportAngle)
+        self.pathExportAngleLayout.addWidget(self.filenameExportAngle)
         self.exportAngleLayout = qt.QHBoxLayout()
-        self.exportAngleLayout.addWidget(self.directoryExportAngle)
+        self.exportAngleLayout.addLayout(self.pathExportAngleLayout)
         self.exportAngleLayout.addWidget(self.exportAngleButton)
         self.tableAndExportAngleLayout = qt.QVBoxLayout()
         self.tableAndExportAngleLayout.addWidget(self.anglesTable)
@@ -215,10 +223,14 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.LinePointLayout = self.logic.get("LinePointLayout")
         self.linePointTable = qt.QTableWidget()
         self.directoryExportLinePoint = ctk.ctkDirectoryButton()
+        self.filenameExportLinePoint = qt.QLineEdit('linePoint.csv')
         self.exportLinePointButton = qt.QPushButton("Export")
         self.exportLinePointButton.enabled = True
+        self.pathExportLinePointLayout = qt.QVBoxLayout()
+        self.pathExportLinePointLayout.addWidget(self.directoryExportLinePoint)
+        self.pathExportLinePointLayout.addWidget(self.filenameExportLinePoint)
         self.exportLinePointLayout = qt.QHBoxLayout()
-        self.exportLinePointLayout.addWidget(self.directoryExportLinePoint)
+        self.exportLinePointLayout.addLayout(self.pathExportLinePointLayout)
         self.exportLinePointLayout.addWidget(self.exportLinePointButton)
         self.tableAndExportLinePointLayout = qt.QVBoxLayout()
         self.tableAndExportLinePointLayout.addWidget(self.linePointTable)
@@ -477,7 +489,12 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.exportDistanceButton.connect('clicked()', self.onExportButton)
 
     def onExportButton(self):
-        self.logic.exportationFunction(self.directoryExportDistance, self.computedDistanceList, 'distance')
+        self.logic.exportationFunction(
+            self.directoryExportDistance,
+            self.filenameExportDistance,
+            self.computedDistanceList,
+            'distance'
+        )
 
     def onComputeAnglesClicked(self):
         fidList = self.logic.selectedFidList
@@ -519,7 +536,12 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
 
 
     def onExportAngleButton(self):
-        self.logic.exportationFunction(self.directoryExportAngle, self.computedAnglesList, 'angle')
+        self.logic.exportationFunction(
+            self.directoryExportAngle,
+            self.filenameExportAngle,
+            self.computedAnglesList,
+            'angle'
+        )
 
     def onComputeLinePointClicked(self):
         fidList = self.logic.selectedFidList
@@ -554,7 +576,12 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.exportLinePointButton.connect('clicked()', self.onExportLinePointButton)
 
     def onExportLinePointButton(self):
-        self.logic.exportationFunction(self.directoryExportLinePoint, self.computedLinePointList, 'linePoint')
+        self.logic.exportationFunction(
+            self.directoryExportLinePoint,
+            self.filenameExportLinePoint,
+            self.computedLinePointList,
+            'linePoint'
+        )
 
 class Q3DCLogic(ScriptedLoadableModuleLogic):
     def __init__(self, interface):
@@ -1655,12 +1682,12 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
 
         return renderer, actor
 
-    def exportationFunction(self, directoryExport, listToExport, typeCalculation):
+    def exportationFunction(self, directoryExport, filenameExport, listToExport, typeCalculation):
         messageBox = ctk.ctkMessageBox()
         messageBox.setWindowTitle(' /!\ WARNING /!\ ')
         messageBox.setIcon(messageBox.Warning)
 
-        fileName = os.path.join(directoryExport.directory, typeCalculation + '.csv')
+        fileName = os.path.join(directoryExport.directory, filenameExport.text)
         if os.path.exists(fileName):
             messageBox.setText('File ' + fileName + ' already exists!')
             messageBox.setInformativeText('Do you want to replace it ?')

--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -4,6 +4,7 @@ import csv, os
 import json
 import time
 import math
+import logging
 
 import numpy as np
 
@@ -17,6 +18,42 @@ except ModuleNotFoundError as e:
     # This requires a network connection!
     slicer.util.pip_install('networkx')
     import networkx as nx
+
+
+class myFilePathButton(qt.QPushButton):
+    '''
+    This file selector button was inspired by ctkDirectoryButton, but it
+    is for selecting CSV files, not directories. It was introduced to
+    address Q3DC issue 18 on Github, which requested the ability to
+    select the filename when exporting results as CSV:
+    https://github.com/DCBIA-OrthoLab/Q3DCExtension/issues/18
+    '''
+    def __init__(self, default_filename):
+        qt.QPushButton.__init__(self, default_filename)
+
+        self.default_filename = default_filename
+        self.default_directory = os.path.abspath('.')
+        self.file_path = os.path.join(self.default_directory, self.default_filename)
+
+        # self.setIcon(qt.QIcon(qt.QStyle.SP_DirIcon))
+        self.updateDisplayText()
+        self.connect('clicked()', self.browse)
+
+    def updateDisplayText(self):
+        self.setText(os.path.abspath(self.file_path))
+
+    def browse(self):
+        new_file_path = qt.QFileDialog.getSaveFileName(
+            self,
+            'Save As',
+            self.file_path,
+            'Comma Separated Value (*.csv)',
+        )
+        if new_file_path != '':
+            slicer.util.delayDisplay('You have not saved until you click Export!')
+            self.file_path = new_file_path
+            self.default_directory = os.path.dirname(self.file_path)
+            self.updateDisplayText()
 
 
 #
@@ -134,11 +171,11 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         # ---------------------------- Directory - Export Button -----------------------------
         self.distanceLayout = self.logic.get("distanceLayout")
         self.distanceTable = qt.QTableWidget()
-        self.directoryExportDistance = ctk.ctkDirectoryButton()
+        self.filenameExportDistance = myFilePathButton('distance.csv')
         self.exportDistanceButton = qt.QPushButton(" Export ")
         self.exportDistanceButton.enabled = True
         self.exportDistanceLayout = qt.QHBoxLayout()
-        self.exportDistanceLayout.addWidget(self.directoryExportDistance)
+        self.exportDistanceLayout.addWidget(self.filenameExportDistance)
         self.exportDistanceLayout.addWidget(self.exportDistanceButton)
         self.tableAndExportLayout = qt.QVBoxLayout()
         self.tableAndExportLayout.addWidget(self.distanceTable)
@@ -181,11 +218,11 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
 
         # ---------------------------- Directory - Export Button -----------------------------
         self.anglesTable = qt.QTableWidget()
-        self.directoryExportAngle = ctk.ctkDirectoryButton()
+        self.filenameExportAngle = myFilePathButton('angle.csv')
         self.exportAngleButton = qt.QPushButton("Export")
         self.exportAngleButton.enabled = True
         self.exportAngleLayout = qt.QHBoxLayout()
-        self.exportAngleLayout.addWidget(self.directoryExportAngle)
+        self.exportAngleLayout.addWidget(self.filenameExportAngle)
         self.exportAngleLayout.addWidget(self.exportAngleButton)
         self.tableAndExportAngleLayout = qt.QVBoxLayout()
         self.tableAndExportAngleLayout.addWidget(self.anglesTable)
@@ -214,11 +251,11 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         # ---------------------------- Directory - Export Button -----------------------------
         self.LinePointLayout = self.logic.get("LinePointLayout")
         self.linePointTable = qt.QTableWidget()
-        self.directoryExportLinePoint = ctk.ctkDirectoryButton()
+        self.filenameExportLinePoint = myFilePathButton('linePoint.csv')
         self.exportLinePointButton = qt.QPushButton("Export")
         self.exportLinePointButton.enabled = True
         self.exportLinePointLayout = qt.QHBoxLayout()
-        self.exportLinePointLayout.addWidget(self.directoryExportLinePoint)
+        self.exportLinePointLayout.addWidget(self.filenameExportLinePoint)
         self.exportLinePointLayout.addWidget(self.exportLinePointButton)
         self.tableAndExportLinePointLayout = qt.QVBoxLayout()
         self.tableAndExportLinePointLayout.addWidget(self.linePointTable)
@@ -477,7 +514,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.exportDistanceButton.connect('clicked()', self.onExportButton)
 
     def onExportButton(self):
-        self.logic.exportationFunction(self.directoryExportDistance, self.computedDistanceList, 'distance')
+        self.logic.exportationFunction(self.filenameExportDistance, self.computedDistanceList, 'distance')
 
     def onComputeAnglesClicked(self):
         fidList = self.logic.selectedFidList
@@ -519,7 +556,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
 
 
     def onExportAngleButton(self):
-        self.logic.exportationFunction(self.directoryExportAngle, self.computedAnglesList, 'angle')
+        self.logic.exportationFunction(self.filenameExportAngle, self.computedAnglesList, 'angle')
 
     def onComputeLinePointClicked(self):
         fidList = self.logic.selectedFidList
@@ -554,7 +591,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.exportLinePointButton.connect('clicked()', self.onExportLinePointButton)
 
     def onExportLinePointButton(self):
-        self.logic.exportationFunction(self.directoryExportLinePoint, self.computedLinePointList, 'linePoint')
+        self.logic.exportationFunction(self.filenameExportLinePoint, self.computedLinePointList, 'linePoint')
 
 class Q3DCLogic(ScriptedLoadableModuleLogic):
     def __init__(self, interface):
@@ -1655,12 +1692,12 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
 
         return renderer, actor
 
-    def exportationFunction(self, directoryExport, listToExport, typeCalculation):
+    def exportationFunction(self, file_path_widget, listToExport, typeCalculation):
         messageBox = ctk.ctkMessageBox()
         messageBox.setWindowTitle(' /!\ WARNING /!\ ')
         messageBox.setIcon(messageBox.Warning)
 
-        fileName = os.path.join(directoryExport.directory, typeCalculation + '.csv')
+        fileName = file_path_widget.file_path
         if os.path.exists(fileName):
             messageBox.setText('File ' + fileName + ' already exists!')
             messageBox.setInformativeText('Do you want to replace it ?')
@@ -1669,7 +1706,7 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
             if choice == messageBox.No:
                 return
         self.exportAsCSV(fileName, listToExport, typeCalculation)
-        slicer.util.delayDisplay("Saved to fileName")
+        slicer.util.delayDisplay(f'Saved to {fileName}')
 
 
     def exportAsCSV(self,filename, listToExport, typeCalculation):

--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -181,7 +181,6 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.tableAndExportLayout.addWidget(self.distanceTable)
         self.tableAndExportLayout.addLayout(self.exportDistanceLayout)
 #       ------------------- 2nd OPTION -------------------
-        self.angleLayout = self.logic.get("angleLayout")
         self.angleGroupBox = self.logic.get("angleGroupBox")
         self.line1LAComboBox = self.logic.get("line1LAComboBox")
         self.fidListComboBoxline1LA = self.logic.get("fidListComboBoxline1LA")
@@ -217,6 +216,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.yawCheckBox.connect('clicked(bool)', self.UpdateInterface)
 
         # ---------------------------- Directory - Export Button -----------------------------
+        self.angleLayout = self.logic.get("angleLayout")
         self.anglesTable = qt.QTableWidget()
         self.filenameExportAngle = myFilePathButton('angle.csv')
         self.exportAngleButton = qt.QPushButton("Export")


### PR DESCRIPTION
This takes the direct approach to solving #18 suggested by @vicory. A text box is added beneath each directory selector widget. Each box is pre-populated with the default filename. The contents of the box are retrieved when the export button is pressed to construct a full path to the save location.