### PR TITLE
EHN: Harmonize UI text and CSV headers

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1681,10 +1681,10 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
             cw.writerow([' Landmark A - Landmark B',  ' R-L Component', ' A-P Component', ' S-I Component', ' 3D Distance '])
             self.writeDistance(cw, listToExport)
         elif typeCalculation == 'linePoint':
-            cw.writerow([' Landmark A - Landmark B',  ' R-L Component', ' A-P Component', ' S-I Component', ' 3D Distance '])
+            cw.writerow([' Landmark A - Landmark B / Landmark X',  ' R-L Component', ' A-P Component', ' S-I Component', ' 3D Distance '])
             self.writeLinePoint(cw, listToExport)
         else:
-            cw.writerow([' Line 1 (Landmark A - Landmark B) /  Line 2 (Landmark A - Landmark B)',  ' YAW ', ' PITCH ', ' ROLL '])
+            cw.writerow([' Line 1 (Landmark A - Landmark B) |  Line 2 (Landmark A - Landmark B)',  ' YAW ', ' PITCH ', ' ROLL '])
             self.writeAngle(cw, listToExport)
         file.close()
         if self.decimalPoint != '.':

--- a/Q3DC/Resources/UI/Q3DC.ui
+++ b/Q3DC/Resources/UI/Q3DC.ui
@@ -306,7 +306,7 @@
         <item>
          <widget class="QLabel" name="label_7">
           <property name="text">
-           <string>Landmarks A:</string>
+           <string>Landmark A:</string>
           </property>
          </widget>
         </item>
@@ -348,7 +348,7 @@
         <item>
          <widget class="QLabel" name="label_5">
           <property name="text">
-           <string>Landmarks B:</string>
+           <string>Landmark B:</string>
           </property>
          </widget>
         </item>
@@ -735,7 +735,7 @@
            </size>
           </property>
           <property name="text">
-           <string>Landmark:</string>
+           <string>Landmark X:</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The headers of CSV files written by Q3DC refer to landmark points by
names similar to what is displayed in the Q3DC UI. This commit brings
these into better agreement. In addition, the headers of linePoint and
angle CSV files is updated to reflect the actual content of those CSVs.