### PR TITLE
RE: issue 42

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -269,9 +269,9 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.computedDistanceList = []
         self.computedAnglesList = []
         self.computedLinePointList = []
-        self.line_point_table.RemoveAllColumns()
-        self.angles_table.RemoveAllColumns()
         self.distance_table.RemoveAllColumns()
+        self.angles_table.RemoveAllColumns()
+        self.line_point_table.RemoveAllColumns()
 
     def enter(self):
         print("enter Q3DC")

--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1359,7 +1359,8 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
         distanceList.append(elementToAdd)
         return distanceList
 
-    def defineDistanceTable(self, table, table_view, distanceList):
+    @staticmethod
+    def defineDistanceTable(table, table_view, distanceList):
         col_names = ('  ', ' R-L Component', ' A-P Component', ' S-I Component', ' 3D Distance ')
         with NodeModify(table):
             table.RemoveAllColumns()

--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -78,14 +78,15 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.logic = Q3DCLogic(self.ui)
         self.logic.UpdateInterface = self.UpdateInterface
 
-        #--------------------------- Scene --------------------------#
+        # -------------------------- Scene ---------------------------
         self.SceneCollapsibleButton = self.ui.SceneCollapsibleButton # this attribute is usefull for Longitudinal quantification extension
         treeView = self.ui.treeView
         treeView.setMRMLScene(slicer.app.mrmlScene())
         treeView.sceneModel().setHorizontalHeaderLabels(["Models"])
         treeView.sortFilterProxyModel().nodeTypes = ['vtkMRMLModelNode','vtkMRMLMarkupsFiducialNode']
         treeView.header().setVisible(False)
-        # --------------- landmark modification --------------
+
+        # ------------------ Landmark Modification -------------------
         self.inputModelLabel = self.ui.inputModelLabel  # this attribute is usefull for Longitudinal quantification extension
         self.inputLandmarksLabel = self.ui.inputLandmarksLabel  # this attribute is usefull for Longitudinal quantification extension
         self.ui.inputModelSelector.setMRMLScene(slicer.mrmlScene)
@@ -97,7 +98,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.ui.landmarkComboBox.connect('currentIndexChanged(QString)', self.UpdateInterface)
         self.ui.surfaceDeplacementCheckBox.connect('stateChanged(int)', self.onSurfaceDeplacementStateChanged)
 
-        # --------------- anatomical legend --------------
+        # --------------------- Anatomical Legend --------------------
         self.suggested_landmarks = self.logic.load_suggested_landmarks(
             self.resourcePath('Data/base_fiducial_legend.csv'))
         self.anatomical_legend_space = self.ui.landmarkModifLayout
@@ -119,11 +120,12 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
 
         self.ui.legendFileButton.connect('clicked()', self.on_select_legend_file_clicked)
 
-        #        ----------------- Compute Mid Point -------------
+        # -------------------- Compute Mid Point ---------------------
         self.ui.landmarkComboBox1.connect('currentIndexChanged(int)', self.UpdateInterface)
         self.ui.landmarkComboBox2.connect('currentIndexChanged(int)', self.UpdateInterface)
         self.ui.defineMiddlePointButton.connect('clicked()', self.onDefineMidPointClicked)
-#        ------------------- 1st OPTION -------------------
+
+        # ------------------- Calculate Distances --------------------
         self.ui.fidListComboBoxA.setMRMLScene(slicer.mrmlScene)
         self.ui.fidListComboBoxB.setMRMLScene(slicer.mrmlScene)
         self.ui.computeDistancesPushButton.connect('clicked()', self.onComputeDistanceClicked)
@@ -133,7 +135,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
                                       lambda: self.logic.UpdateLandmarkComboboxA(self.ui.fidListComboBoxA, self.ui.landmarkComboBoxA))
         self.ui.fidListComboBoxB.connect('currentNodeChanged(vtkMRMLNode*)',
                                       lambda: self.logic.UpdateLandmarkComboboxA(self.ui.fidListComboBoxB, self.ui.landmarkComboBoxB))
-        # ---------------------------- Directory - Export Button -----------------------------
+        # ---------------------- Save Distances ----------------------
         self.distanceTable = qt.QTableWidget()
         self.directoryExportDistance = ctk.ctkDirectoryButton()
         self.filenameExportDistance = qt.QLineEdit('distance.csv')
@@ -148,7 +150,8 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.tableAndExportLayout = qt.QVBoxLayout()
         self.tableAndExportLayout.addWidget(self.distanceTable)
         self.tableAndExportLayout.addLayout(self.exportDistanceLayout)
-#       ------------------- 2nd OPTION -------------------
+
+        # --------------------- Calculate Angles ---------------------
         self.ui.fidListComboBoxline1LA.setMRMLScene(slicer.mrmlScene)
         self.ui.fidListComboBoxline1LB.setMRMLScene(slicer.mrmlScene)
         self.ui.fidListComboBoxline2LA.setMRMLScene(slicer.mrmlScene)
@@ -169,8 +172,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.ui.pitchCheckBox.connect('clicked(bool)', self.UpdateInterface)
         self.ui.rollCheckBox.connect('clicked(bool)', self.UpdateInterface)
         self.ui.yawCheckBox.connect('clicked(bool)', self.UpdateInterface)
-
-        # ---------------------------- Directory - Export Button -----------------------------
+        # ----------------------- Save Angles ------------------------
         self.anglesTable = qt.QTableWidget()
         self.directoryExportAngle = ctk.ctkDirectoryButton()
         self.filenameExportAngle = qt.QLineEdit('angle.csv')
@@ -185,7 +187,8 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.tableAndExportAngleLayout = qt.QVBoxLayout()
         self.tableAndExportAngleLayout.addWidget(self.anglesTable)
         self.tableAndExportAngleLayout.addLayout(self.exportAngleLayout)
-#       ------------------- 3rd OPTION -------------------
+
+        # -------------- Calculate Line-Point Distances --------------
         self.ui.fidListComboBoxlineLA.setMRMLScene(slicer.mrmlScene)
         self.ui.fidListComboBoxlineLB.setMRMLScene(slicer.mrmlScene)
         self.ui.fidListComboBoxlinePoint.setMRMLScene(slicer.mrmlScene)
@@ -198,7 +201,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.ui.computeLinePointPushButton.connect('clicked()', self.onComputeLinePointClicked)
         self.ui.lineLAComboBox.connect('currentIndexChanged(int)', self.UpdateInterface)
         self.ui.lineLBComboBox.connect('currentIndexChanged(int)', self.UpdateInterface)
-        # ---------------------------- Directory - Export Button -----------------------------
+        # ---------------- Save Line-Point Distances -----------------
         self.linePointTable = qt.QTableWidget()
         self.directoryExportLinePoint = ctk.ctkDirectoryButton()
         self.filenameExportLinePoint = qt.QLineEdit('linePoint.csv')
@@ -213,6 +216,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.tableAndExportLinePointLayout = qt.QVBoxLayout()
         self.tableAndExportLinePointLayout.addWidget(self.linePointTable)
         self.tableAndExportLinePointLayout.addLayout(self.exportLinePointLayout)
+
         # INITIALISATION:
         slicer.mrmlScene.AddObserver(slicer.mrmlScene.EndCloseEvent, self.onCloseScene)
         self.UpdateInterface()

--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -212,7 +212,12 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.ui.lineLAComboBox.connect('currentIndexChanged(int)', self.UpdateInterface)
         self.ui.lineLBComboBox.connect('currentIndexChanged(int)', self.UpdateInterface)
         # ---------------- Save Line-Point Distances -----------------
-        self.linePointTable = qt.QTableWidget()
+        self.line_point_table = slicer.vtkMRMLTableNode()
+        self.line_point_table.SetSaveWithScene(False)
+        self.line_point_table.SetLocked(True)
+        slicer.mrmlScene.AddNode(self.line_point_table)
+        self.line_point_table_view = slicer.qMRMLTableView()
+        self.line_point_table_view.setMRMLTableNode(self.line_point_table)
         self.directoryExportLinePoint = ctk.ctkDirectoryButton()
         self.filenameExportLinePoint = qt.QLineEdit('linePoint.csv')
         self.exportLinePointButton = qt.QPushButton("Export")
@@ -224,7 +229,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.exportLinePointLayout.addLayout(self.pathExportLinePointLayout)
         self.exportLinePointLayout.addWidget(self.exportLinePointButton)
         self.tableAndExportLinePointLayout = qt.QVBoxLayout()
-        self.tableAndExportLinePointLayout.addWidget(self.linePointTable)
+        self.tableAndExportLinePointLayout.addWidget(self.line_point_table_view)
         self.tableAndExportLinePointLayout.addLayout(self.exportLinePointLayout)
 
         # INITIALISATION:
@@ -264,9 +269,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.computedDistanceList = []
         self.computedAnglesList = []
         self.computedLinePointList = []
-        self.linePointTable.clear()
-        self.linePointTable.setRowCount(0)
-        self.linePointTable.setColumnCount(0)
+        self.line_point_table.RemoveAllColumns()
         self.angles_table.RemoveAllColumns()
         self.distance_table.RemoveAllColumns()
 
@@ -562,8 +565,9 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
             landmarkDescription = slicer.mrmlScene.GetNodesByName(fidListIter).GetItemAsObject(0). \
                 GetAttribute("landmarkDescription")
             if not landmarkDescription:
-                self.logic.warningMessage(fidListIter + ' is not connected to a model. Please use "Add and Move '
-                                                        'Landmarks" panel to connect the landmarks to a model.')
+                self.logic.warningMessage(
+                    f'{fidListIter} is not connected to a model. Please use "Add and Move '
+                    'Landmarks" panel to connect the landmarks to a model.')
                 return
         if self.computedDistanceList:
             self.exportDistanceButton.disconnect('clicked()', self.onExportButton)
@@ -600,8 +604,8 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
                 GetAttribute("landmarkDescription")
             if not landmarkDescription:
                 self.logic.warningMessage(
-                        f'{fidListIter} is not connected to a model. Please use "Add and Move '
-                        'Landmarks" panel to connect the landmarks to a model.')
+                    f'{fidListIter} is not connected to a model. Please use "Add and Move '
+                    'Landmarks" panel to connect the landmarks to a model.')
                 return
         if self.computedAnglesList:
             self.exportAngleButton.disconnect('clicked()', self.onExportAngleButton)
@@ -645,13 +649,14 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
             landmarkDescription = slicer.mrmlScene.GetNodesByName(fidListIter).GetItemAsObject(0). \
                 GetAttribute("landmarkDescription")
             if not landmarkDescription:
-                self.logic.warningMessage(fidListIter + ' is not connected to a model. Please use "Add and Move '
-                                                        'Landmarks" panel to connect the landmarks to a model.')
+                self.logic.warningMessage(
+                    f'{fidListIter} is not connected to a model. Please use "Add and Move '
+                    'Landmarks" panel to connect the landmarks to a model.')
                 return
         if self.computedLinePointList:
             self.exportLinePointButton.disconnect('clicked()', self.onExportLinePointButton)
-            self.layout.removeWidget(self.linePointTable)
-            self.layout.removeItem(self.tableAndExportLinePointLayout)
+        else:
+            self.ui.LinePointLayout.addLayout(self.tableAndExportLinePointLayout)
         self.computedLinePointList = self.logic.addOnLinePointList(self.computedLinePointList,
                                                            self.ui.lineLAComboBox.currentText,
                                                            self.ui.lineLBComboBox.currentText,
@@ -660,8 +665,8 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
                                                            self.ui.linePointComboBox.currentText,
                                                                    fidListPoint,
                                                            )
-        self.linePointTable = self.logic.defineDistanceLinePointTable(self.linePointTable, self.computedLinePointList)
-        self.ui.LinePointLayout.addLayout(self.tableAndExportLinePointLayout)
+        self.logic.defineDistanceLinePointTable(
+            self.line_point_table, self.line_point_table_view, self.computedLinePointList)
         self.exportLinePointButton.connect('clicked()', self.onExportLinePointButton)
 
     def onExportLinePointButton(self):
@@ -1643,59 +1648,33 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
         linePointList.append(elementToAdd)
         return linePointList
 
-    def defineDistanceLinePointTable(self, table, distanceList):
-        table.clear()
-        table.setRowCount(distanceList.__len__())
-        table.setColumnCount(5)
-        table.setMinimumHeight(50*distanceList.__len__())
-        table.setHorizontalHeaderLabels(['  ', ' R-L Component', ' A-P Component', ' S-I Component', ' 3D Distance '])
-        i = 0
-        for element in distanceList:
-            landmarkALineName = element.landmarkALineName
-            landmarkBLineName = element.landmarkBLineName
-            landmarkPoint = element.landmarkPointName
-
-            label = qt.QLabel(' ' + str(landmarkALineName) + ' - ' + str(landmarkBLineName) + ' / ' + str(landmarkPoint) + ' ')
-            label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-            table.setCellWidget(i, 0,label)
-            if element.RLComponent != None:
-                label = qt.QLabel(element.RLComponent)
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 1, label)
-            else:
-                label = qt.QLabel(' - ')
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 1, label)
-
-            if element.APComponent != None:
-                label = qt.QLabel(element.APComponent)
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 2, label)
-            else:
-                label = qt.QLabel(' - ')
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 2, label)
-
-            if element.SIComponent != None:
-                label = qt.QLabel(element.SIComponent)
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 3, label)
-            else:
-                label = qt.QLabel(' - ')
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 3, label)
-
-            if element.ThreeDComponent != None:
-                label = qt.QLabel(element.ThreeDComponent)
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 4, label)
-            else:
-                label = qt.QLabel(' - ')
-                label.setStyleSheet('QLabel{qproperty-alignment:AlignCenter;}')
-                table.setCellWidget(i, 4, label)
-
-            i += 1
-        return table
+    @staticmethod
+    def defineDistanceLinePointTable(table, table_view, distanceList):
+        col_names = ('  ', ' R-L Component', ' A-P Component', ' S-I Component', ' 3D Distance ')
+        with NodeModify(table):
+            table.RemoveAllColumns()
+            for col_name in col_names:
+                table.AddColumn().SetName(col_name)
+            table.SetUseColumnNameAsColumnHeader(True)
+            for element in distanceList:
+                new_row_index = table.AddEmptyRow()
+                landmarkALineName = element.landmarkALineName
+                landmarkBLineName = element.landmarkBLineName
+                landmarkPoint = element.landmarkPointName
+                table.SetCellText(new_row_index, 0,
+                    f' {landmarkALineName} - {landmarkBLineName} / {landmarkPoint} ')
+                col_contents = (
+                    element.RLComponent,
+                    element.APComponent,
+                    element.SIComponent,
+                    element.ThreeDComponent
+                )
+                for col_idx, content in enumerate(col_contents, start=1):
+                    if content is None:
+                        content = ' - '
+                    table.SetCellText(new_row_index, col_idx, str(content))
+        table_view.resizeColumnsToContents()
+        table_view.setMinimumHeight(50 * len(distanceList))
 
     def drawLineBetween2Landmark(self, landmark1label, landmark2label, fidList1, fidList2):
         if not fidList1 or not fidList2 or not landmark1label or not landmark2label:


### PR DESCRIPTION
This is a very superficial change to address #42. The benefits of `vtkMRMLTableNode` are not really seen here. (There is a reduction in LOC though.)

For example, the old system for saving the data is maintained. The data still actually lives in lists of special-purpose classes. (Each object represents a row. There is a class for rows of each table.) It would be better to make the table itself the authoritative repository of each kind of data.

What is the best way to save the contents of a `vtkMRMLTableNode` to a CSV file?

- [x] `SaveWithScene` is set to `False`

Should I create `q3d.measurements.distance` as an alias for `q3dc.distance_table`, and similarly for the other kinds of measurements?

Let's not merge this right away as we need to give Lucia et al. time to evaluate PRs #45 and #47.