### PR TITLE
BUG: Fix angle export to csv. 

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1839,21 +1839,21 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
             landmarkBLine2Name = element.landmarkBLine2Name
 
             label = landmarkALine1Name + '-' + landmarkBLine1Name + ' | ' + landmarkALine2Name + '-' + landmarkBLine2Name
-            signY = np.sign(element.Yaw)
-            signP = np.sign(element.Pitch)
-            signR = np.sign(element.Roll)
 
             if element.Yaw:
+                signY = np.sign(element.Yaw)
                 YawLabel = str(element.Yaw) +' | '+str(signY*(180-abs(element.Yaw)))
             else:
                 YawLabel = '-'
 
             if element.Pitch:
+                signP = np.sign(element.Pitch)
                 PitchLabel = str(element.Pitch)+' | '+str(signP*(180-abs(element.Pitch)))
             else:
                 PitchLabel = '-'
 
             if element.Roll:
+                signR = np.sign(element.Roll)
                 RollLabel = str(element.Roll)+' | '+str(signR*(180-abs(element.Roll)))
             else:
                 RollLabel = '-'


### PR DESCRIPTION
If an angle is `None`, then that sign can't be precomputed; this causes an error and the file is not populated. Move that computation within each corresponding `if` block to fix the issue.

This resolves #52.

Edit - improved the commit message and description.