### PR TITLE
BUG: Stop adding extra landmarks during placement.

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1159,7 +1159,7 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
                 landmark2ID = landmarkDescription[midPointID]["midPoint"]["Point2"]
                 coord = self.calculateMidPointCoord(fidList, landmark1ID, landmark2ID)
                 index = fidList.GetNthControlPointIndexByID(midPointID)
-                fidList.SetNthFiducialPositionFromArray(index, coord)
+                fidList.SetNthControlPointPositionFromArray(index, coord, fidList.PositionPreview)
                 if landmarkDescription[midPointID]["projection"]["isProjected"]:
                     hardenModel = slicer.app.mrmlScene().GetNodeByID(fidList.GetAttribute("hardenModelID"))
                     landmarkDescription[midPointID]["projection"]["closestPointIndex"] = \
@@ -1279,7 +1279,7 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
         landmarkCoord = [-1, -1, -1]
         inputModelPolyData.GetPoints().GetPoint(indexClosestPoint, landmarkCoord)
         print(landmarkCoord)
-        fidNode.SetNthFiducialPositionFromArray(landmarkID,landmarkCoord)
+        fidNode.SetNthControlPointPositionFromArray(landmarkID, landmarkCoord, fidNode.PositionPreview)
 
     def projectOnSurface(self, modelOnProject, fidNode, selectedFidReflID):
         if selectedFidReflID:


### PR DESCRIPTION
Switch landmark placement to use `Preview` placement mode.

Resolves #43.

This is the same solution that I used in a [similar problem](https://github.com/DCBIA-OrthoLab/CMFreg/pull/30/files#diff-6a5f6a15ba5b1746ebc2e27ff1a97974fafc170977ebc2e1f42720404d323c7eL1036-L1131) for CMFreg. More information about the issue is described in the conversation there. 