### PR TITLE
BUG: Prevent crash when deleting landmark.

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1209,6 +1209,12 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
 
     def onPointRemovedEvent(self, obj, event):
         logging.debug("markup deleting")
+
+        # ensure that onPointModified won't be called
+        tag = self.decodeJSON(obj.GetAttribute("PointModifiedEventTag"))
+        logging.info('Modified %r', tag)
+        obj.RemoveObserver(tag["PointModifiedEventTag"])
+
         landmarkDescription = self.decodeJSON(obj.GetAttribute("landmarkDescription"))
         IDs = []
         for ID, value in landmarkDescription.items():


### PR DESCRIPTION
There is an explanation of this solution in the comments of #57.

> The issue is that, when a point is deleted, `onPointModifiedEvent` is also called. The observer is removed, and `time.sleep` begins. The point is then deleted. Once `time.sleep` ends, the observer is re-added to a nonexistant point, and slicer crashes.
>
> Removing `time.sleep` might fix this issue, however that delay is added to prevent stuttering while points are projected to the models. The other approach would be to prevent `onPointModifiedEvent` being invoked when a point is deleted.

Resolves #57.