### PR TITLE
BUG: Wrong distance between landmarks.

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1415,7 +1415,7 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
         fidIndexB = fidListB.GetNthControlPointIndexByID(fidIDB)
 
         point1 = np.array(fidListA.GetMarkupPointVector(fidIndexA, 0))
-        point2 = np.array(fidListA.GetMarkupPointVector(fidIndexB, 0))
+        point2 = np.array(fidListB.GetMarkupPointVector(fidIndexB, 0))
 
         args = point1, point2
 


### PR DESCRIPTION
Wrong distance computed between landmarks of different fiducial lists due to a typo in getDistanceArgs.

Amazing! A single letter caused all these problems. 

Resolves #70.