### PR TITLE
BUG: Fix option to place new landmark without projecting to surface.

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -95,6 +95,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
         self.ui.inputLandmarksSelector.connect('currentNodeChanged(vtkMRMLNode*)', self.onLandmarksChanged)
         self.ui.landmarkComboBox.connect('currentIndexChanged(QString)', self.UpdateInterface)
         self.ui.surfaceDeplacementCheckBox.connect('stateChanged(int)', self.onSurfaceDeplacementStateChanged)
+        self.ui.loadLandmarksOnSurfaceCheckBox.connect('stateChanged(int)', self.onLoadLandmarksOnSurfaceStateChanged)
 
         # --------------------- Anatomical Legend --------------------
         self.suggested_landmarks = self.logic.load_suggested_landmarks(
@@ -484,7 +485,7 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
             self.logic.selectedFidList = self.ui.inputLandmarksSelector.currentNode()
             self.logic.selectedModel = self.ui.inputModelSelector.currentNode()
             if self.ui.inputLandmarksSelector.currentNode():
-                onSurface = self.ui.loadLandmarksOnSurfacCheckBox.isChecked()
+                onSurface = self.ui.loadLandmarksOnSurfaceCheckBox.isChecked()
                 self.logic.connectLandmarks(self.ui.inputModelSelector,
                                       self.ui.inputLandmarksSelector,
                                       onSurface)
@@ -505,6 +506,9 @@ class Q3DCWidget(ScriptedLoadableModuleWidget):
                 self.logic.warningMessage("Please select a fiducial list")
         else:
             self.logic.warningMessage("Please select a model")
+
+    def onLoadLandmarksOnSurfaceStateChanged(self):
+        self.logic.projectNewPoints = self.ui.loadLandmarksOnSurfaceCheckBox.isChecked()
 
     def onSurfaceDeplacementStateChanged(self):
         activeInput = self.logic.selectedModel
@@ -695,6 +699,7 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
         self.selectedFidList = None
         self.current_suggested_landmarks = None
         self.enable_legend_labels = True
+        self.projectNewPoints = True
         self.numberOfDecimals = 3
         self.tolerance = 1e-5
         system = qt.QLocale().system()
@@ -1105,7 +1110,7 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
         landmarkLabel = obj.GetNthMarkupLabel(numOfMarkups - 1)
         landmarkDescription[markupID]["landmarkLabel"] = landmarkLabel
         landmarkDescription[markupID]["projection"] = dict()
-        landmarkDescription[markupID]["projection"]["isProjected"] = True
+        landmarkDescription[markupID]["projection"]["isProjected"] = self.projectNewPoints
         # The landmark will be projected by onPointModifiedEvent
         landmarkDescription[markupID]["midPoint"] = dict()
         landmarkDescription[markupID]["midPoint"]["definedByThisMarkup"] = list()

--- a/Q3DC/Resources/UI/Q3DC.ui
+++ b/Q3DC/Resources/UI/Q3DC.ui
@@ -135,12 +135,15 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="loadLandmarksOnSurfacCheckBox">
+         <widget class="QCheckBox" name="loadLandmarksOnSurfaceCheckBox">
           <property name="text">
            <string>On Surface</string>
           </property>
           <property name="checked">
            <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>If checked, newly placed and loaded landmarks will snap to the surface.</string>
           </property>
          </widget>
         </item>
@@ -198,6 +201,9 @@
           </property>
           <property name="checked">
            <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>If checked, this landmark will snap to the surface.</string>
           </property>
          </widget>
         </item>
@@ -300,6 +306,9 @@
           </property>
           <property name="text">
            <string>On Surface</string>
+          </property>
+          <property name="toolTip">
+           <string>If checked, this midpoint will snap to the surface.</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The checkbox "On Surface" currently only changed whether a fiducial list would be projected to the surface when it was loaded; any new landmarks added to the list would be projected regardless.

This change makes new landmarks project only if "On Surface" is checked.

Resolves #73 