### PR TITLE
BUG: Allow landmark name to contain an apostrophe.

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1619,13 +1619,10 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
         messageBox.exec_()
 
     def encodeJSON(self, input):
-        encodedString = json.dumps(input)
-        encodedString = encodedString.replace('\"', '\'')
-        return encodedString
+        return json.dumps(input)
 
     def decodeJSON(self, input):
         if input:
-            input = input.replace('\'','\"')
             return json.loads(input)
         return None
 


### PR DESCRIPTION
`Q3DCLogic.encodeJSON`, `Q3DCLogic.decodeJSON` both replaced `"` by `'`... it's been this way since 72746506 (2015), but I don't see any explanation of _why_ it was done that way. See https://github.com/DCBIA-OrthoLab/Q3DCExtension/blob/727465067c94719831c6dcc7cc2ef410c3c7160e/Q3DC/Q3DC.py#L1480-L1487

~~This change shouldn't break any compatibility with existing files. `json.loads` can parse single-quoted JSON, and if a file were successfully created with the replacement then it should be valid json, just single-quoted. So then it _should_ be parsable after this commit.~~

Resolves #75.