### PR TITLE
BUG: Fix backwards compatibility of JSON format.

### DIFF
--- a/Q3DC/Q3DC.py
+++ b/Q3DC/Q3DC.py
@@ -1623,7 +1623,15 @@ class Q3DCLogic(ScriptedLoadableModuleLogic):
 
     def decodeJSON(self, input):
         if input:
-            return json.loads(input)
+            try:
+                # if parsing fails, then the json was saved using the old single-quoted replacement
+                return json.loads(input)
+            except json.JSONDecodeError:
+                # if parsing fails after the replacement, then the input would contain something like
+                # ... 'landmarkName': 'UR1'', ... which cannot be automatically recovered.
+                input = input.replace("'", '"')
+                return json.loads(input)
+
         return None
 
     def UpdateLandmarkComboboxA(self, fidListCombobox, landmarkCombobox):


### PR DESCRIPTION
https://github.com/DCBIA-OrthoLab/Q3DCExtension/pull/76 broke compatibility with old files, since `json.loads` cannot parse single-quoted json (oops!).

To fix this, I parse json using the substitution if parsing without it fails. This way old files can be loaded, and all new files will be saved with double-quotes and be able to contain arbitrary landmark names.
