### PR TITLE
DOC: Document the landmarkDescription attributes and JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ http://www.apache.org/licenses/LICENSE-2.0
 
 The license file was added at revision 6cc3ad4 on 2020-12-10, but you may consider that the license applies to all prior revisions as well.
 
+## File Formats
+
+Q3DC allows users to define midpoint and projection constraints on points in a Slicer Fiducial list. Saving the Markups with the usual Slicer save dialog will preserve those connections. See [landmarkDescription.md][landmarkDescription] for more information on how MRML attributes are used to do this.
+
+Q3DC also allows users to export computed measurements to CSV files. Note that these files do not encode any of the midpoint and projection constraints as the Markups list does; they only contain the computed measurements in the same tabular format as is displayed in the Q3DC UI.
+
+[landmarkDescription]: ./docs/landmarkDescription.md

--- a/docs/landmarkDescription.json
+++ b/docs/landmarkDescription.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DCBIA-OrthoLab/Q3DCExtension/master/docs/landmarkDescription.schema.json",
+  "1": {
+    "landmarkLabel": "A",
+    "projection": {
+      "isProjected": true,
+      "closestPointIndex": 29659
+    },
+    "midPoint": {
+      "definedByThisMarkup": [
+        "3"
+      ],
+      "isMidPoint": false,
+      "Point1": null,
+      "Point2": null
+    }
+  },
+  "2": {
+    "landmarkLabel": "B",
+    "projection": {
+      "isProjected": true,
+      "closestPointIndex": 27760
+    },
+    "midPoint": {
+      "definedByThisMarkup": [
+        "3"
+      ],
+      "isMidPoint": false,
+      "Point1": null,
+      "Point2": null
+    }
+  },
+  "3": {
+    "landmarkLabel": "A_B",
+    "projection": {
+      "isProjected": false,
+      "closestPointIndex": null
+    },
+    "midPoint": {
+      "definedByThisMarkup": [],
+      "isMidPoint": true,
+      "Point1": "1",
+      "Point2": "2"
+    }
+  }
+}

--- a/docs/landmarkDescription.md
+++ b/docs/landmarkDescription.md
@@ -1,0 +1,31 @@
+# SlicerCMF Landmarks Attributes 
+
+Q3DC and related SlicerCMF extensions use [MRML node attributes][attributes] to encode 
+constraints on landmark positions like projecting a point to the surface of a model, or
+keeping a point at the midpoint of two others.
+
+[attributes]: https://slicer.readthedocs.io/en/latest/developer_guide/mrml_overview.html#mrml-node-attributes
+
+## `connectedModelID`
+
+Stores the ID of the model to which landmarks are projected.
+
+## `hardenModelID`
+
+Since the connected model may be transformed, the _hardened_ model has these transforms 
+applied such that all its coordinates are in world space, suitable for computing landmark
+projections. 
+
+## `landmarkDescription`
+
+A JSON string storing landmark constraints and related metadata. See the 
+[`landmarkDescription` JSON Schema][schema] or open in the 
+[Atlassian JSON Schema Viewer][viewer] for details. The JSON contains the following:
+
+- Landmark legend labels (overriding `vtkMRMLMarkupsNode::MarkupLabelFormat`)
+- Projection to model surface constraints
+- Midpoint constraints
+- Constraint dependencies (i.e. if a landmark is modified, which constrained landmarks should also update)
+
+[schema]: ./landmarkDescription.schema.json
+[viewer]: https://json-schema.app/view/%23?url=https%3A%2F%2Fraw.githubusercontent.com%2FDCBIA-OrthoLab%2FQ3DCExtension%2Fmaster%2Fdocs%2FlandmarkDescription.schema.json

--- a/docs/landmarkDescription.schema.json
+++ b/docs/landmarkDescription.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Landmark Description",
+  "description": "vtkMRMLFiducialNode Attribute \"landmarkDescription\" used by Q3DC and related SlicerCMF modules.",
+  "type": "object",
+  "patternProperties": {
+    "^\\d+$": {
+      "type": "object",
+      "properties": {
+        "landmarkLabel": {
+          "type": "string",
+          "description": "Label of this landmark. Overrides vtkMRMLMarkupsNode::MarkupLabelFormat."
+        },
+        "projection": {
+          "type": "object",
+          "description": "Metadata to project the landmark to a hardened model.",
+          "properties": {
+            "isProjected": {
+              "type": "boolean",
+              "description": "If true, project this point onto the hardened model."
+            },
+            "closestPointIndex": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "description": "Index of the closest point in the hardened model, or null if not projected."
+            }
+          },
+          "required": [
+            "isProjected",
+            "closestPointIndex"
+          ]
+        },
+        "midPoint": {
+          "type": "object",
+          "description": "Metadata to update the midpoint between landmarks.",
+          "properties": {
+            "definedByThisMarkup": {
+              "type": "array",
+              "description": "Midpoint landmarks IDs that depend on this landmark's position. Used to update midpoint positions when this landmark is moved.",
+              "items": [
+                {
+                  "type": "string",
+                  "description": "A Landmark ID."
+                }
+              ]
+            },
+            "isMidPoint": {
+              "type": "boolean",
+              "description": "If true, constrain this landmark's position to the midpoint of Point1 and Point2."
+            },
+            "Point1": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A landmark ID, or null if this landmark is not a midpoint."
+            },
+            "Point2": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "description": "A landmark ID, or null if this landmark is not a midpoint."
+            }
+          },
+          "required": [
+            "definedByThisMarkup",
+            "isMidPoint",
+            "Point1",
+            "Point2"
+          ]
+        }
+      },
+      "required": [
+        "landmarkLabel",
+        "projection",
+        "midPoint"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- Explain how the vtkMRMLMarkupsFiducialNode attributes are used
- Add a schema for the landmarkDescription JSON
- Add a simple example of the landmarkDescription JSON

There is a link to open the schema in [Atlassian Schema Viewer (master)][viewer-master]; I created the link against the master branch; this PR has obviously not yet been merged, so the link is currently broken. Here's a link against this branch, to see how it will look: [Viewer (78-file-format)][viewer-78]

[viewer-master]: https://json-schema.app/view/%23?url=https%3A%2F%2Fraw.githubusercontent.com%2FDCBIA-OrthoLab%2FQ3DCExtension%2Fmaster%2Fdocs%2FlandmarkDescription.schema.json
[viewer-78]: https://json-schema.app/view/%23?url=https%3A%2F%2Fraw.githubusercontent.com%2FDCBIA-OrthoLab%2FQ3DCExtension%2F78-file-format%2Fdocs%2FlandmarkDescription.schema.json

Resolves #78 